### PR TITLE
Adding boost dependency to soplex-config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,8 @@ endif()
 # export compilation settings to header file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/soplex/config.h.in ${PROJECT_BINARY_DIR}/soplex/config.h @ONLY)
 
+configure_file(${PROJECT_SOURCE_DIR}/soplex-config.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/soplex-config.cmake" @ONLY)
+
 add_subdirectory(src)
 add_subdirectory(tests/c_interface)
 add_subdirectory(check)

--- a/soplex-config.cmake.in
+++ b/soplex-config.cmake.in
@@ -6,3 +6,8 @@ set(SOPLEX_LIBRARIES libsoplex)
 set(SOPLEX_PIC_LIBRARIES libsoplex-pic)
 set(SOPLEX_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 set(SOPLEX_FOUND TRUE)
+
+if(@SOPLEX_WITH_BOOST@)
+  find_package(Boost 1.71.0)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()


### PR DESCRIPTION
This PR adds a boost dependency to the soplex-config.cmake in case soplex has been compiled using boost.

Resolves #12 