### PR TITLE
Add Webdemo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ doc/html/
 doc/latex/
 faqdata.php
 faq.inc
+# webdemo
+build_webdemo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ include(CPack)
 
 option(ZLIB "Use ZLIB" ON)
 option(GMP "Use GMP" ON)
+option(EMSCRIPTEN_HTML "Emscripten HTML output" OFF)
 option(STATIC_GMP "Prefer static GMP lib" OFF)
 option(BOOST "Use Boost (required to build the binary). Disable if you only want to build libsoplex." ON)
 option(QUADMATH "should quadmath library be used" OFF)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -116,6 +116,25 @@ and link with the GMP callable library.
 Note for building SCIP with SoPlex:  If SoPlex was built with GMP, then SCIP
 also needs to be built with GMP (default).
 
+### Webdemo
+
+SoPlex can be compiled into a single HTML file and used in a browser. This
+requires `emscripten` to be installed from their website (unfortunately, e.g.
+`sudo apt install emscripten` in Ubuntu Linux is broken):
+
+    https://emscripten.org/docs/getting_started/downloads.html
+
+Then, run
+
+    sh build_webdemo.sh
+
+This will create the file `build_webdemo/bin/soplex.html`. For fast edit
+iterations run
+
+    find src | entr -rs 'make -C build_webdemo soplex; echo'
+
+This will rebuild `soplex.html` every time a source file is modified (e.g.
+from Visual Studio Code).
 
 Using the Library
 =================

--- a/build_webdemo.sh
+++ b/build_webdemo.sh
@@ -1,0 +1,26 @@
+script_path=$(realpath $(dirname $0))
+build_dir="build_webdemo"
+
+# interesting for Node.js: -sNODERAWFS=1, allows direct os filesystem access
+LDFLAGS=$(echo $(cat << EOF
+-sUSE_ZLIB=1
+-sINVOKE_RUN=0
+-sMODULARIZE=1
+-sEXPORTED_RUNTIME_METHODS=['FS','callMain']
+-sEXPORT_NAME='SoPlex'
+-sSINGLE_FILE
+-sALLOW_MEMORY_GROWTH=1
+--shell-file ${script_path}/src/soplex_webdemo_shell.html
+EOF
+))
+
+# compare https://stackoverflow.com/a/6481016
+physical_cores=$(grep ^cpu\\scores /proc/cpuinfo | uniq | awk '{print $4}')
+
+cd ${script_path} &&
+rm -rf ${build_dir} &&
+mkdir ${build_dir} &&
+cd ${build_dir} &&
+LDFLAGS=$LDFLAGS emcmake cmake .. \
+-DBOOST=off -DGMP=off -DCMAKE_BUILD_TYPE=Release -DEMSCRIPTEN_HTML=on &&
+emmake make -j ${physical_cores}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,6 +192,11 @@ set_target_properties(libsoplexshared PROPERTIES CXX_VISIBILITY_PRESET default)
 add_executable(soplex soplexmain.cpp)
 target_link_libraries(soplex LINK_PUBLIC libsoplex ${Boost_LIBRARIES})
 
+if(EMSCRIPTEN AND EMSCRIPTEN_HTML)
+    set_target_properties(soplex PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/soplex_webdemo_shell.html)
+    set(CMAKE_EXECUTABLE_SUFFIX ".html")
+endif()
+
 if(CMAKE_BUILD_TYPE EQUAL "Debug")
    find_package(Sanitizers)
    add_sanitizers(soplex)

--- a/src/soplex_webdemo_shell.html
+++ b/src/soplex_webdemo_shell.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<!-- compare https://github.com/emscripten-core/emscripten/blob/main/src/shell_minimal.html -->
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>SoPlex</title>
+  </head>
+  <body>
+    <div style="display: grid; grid-template-columns: 1fr 1fr">
+      <textarea id="input" style="height: 700px">
+      </textarea>    
+      <textarea id="output"></textarea>    
+      <button id="run">Optimize!</button>
+    </div>
+    {{{ SCRIPT }}}
+    <script type='text/javascript'>
+      main = async () => {
+        const printInTextarea = function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          // These replacements are necessary if you render to raw HTML
+          //text = text.replace(/&/g, "&amp;");
+          //text = text.replace(/</g, "&lt;");
+          //text = text.replace(/>/g, "&gt;");
+          //text = text.replace('\n', '<br>', 'g');
+          // console.log(text);
+          if (element) {
+            element.value += text + "\n";
+            element.scrollTop = element.scrollHeight; // focus on bottom
+          }
+        }
+
+        const soplex = await SoPlex({
+          print: printInTextarea,
+          printErr: printInTextarea
+        })        
+
+        const inputTextarea = document.getElementById('input');
+        inputTextarea.value = `Maximize 
+ obj: x1 + 2 x2 + 3 x3 + x4
+Subject To
+ c1: - x1 + x2 + x3 + 10 x4 <= 20
+ c2: x1 - 3 x2 + x3 <= 30
+ c3: x2 - 3.5 x4 = 0
+Bounds
+ 0 <= x1 <= 40
+ 2 <= x4 <= 3
+General
+ x4
+End`;
+
+        const element = document.getElementById('output');
+        const clearOutput = (v) => {
+          element.value = v || '';
+        }
+
+        clearOutput('Click on "Optimize!"') // clear browser cache
+
+        const runButton = document.getElementById('run');
+        runButton.addEventListener("click", () => {
+          clearOutput()
+          const inputFilename = 'inputFile.lp'
+          soplex.FS.writeFile(inputFilename, inputTextarea.value)
+          soplex.callMain([inputFilename])
+        })
+
+      }
+
+      main()
+
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Hi everybody & happy New Year!

Thanks for changing the license to full open-source, this is a milestone for contributors.

I've added code for compiling a webdemo for SoPlex, so it can be run in a browser serverlessly from a single HTML file of around 1.6 MB. This is done with Emscripten, a C/C++ to JavaScript/WebAssembly compiler. The integration with cmake is a little hacky (by design, Emscripten overrides a lot of parameters), so it needs a script to trigger the build. I've wrapped everything up in this pull request.