### PR TITLE
Support for c++20

### DIFF
--- a/src/soplex/dsvectorbase.h
+++ b/src/soplex/dsvectorbase.h
@@ -103,7 +103,7 @@ public:
    /** Creates a DSVectorBase ready to hold \p n nonzeros. However, the memory is automatically enlarged, if more
     *  nonzeros are added to the DSVectorBase.
     */
-   explicit DSVectorBase<R>(int n = 8)
+   explicit DSVectorBase(int n = 8)
       : theelem(0)
    {
       allocMem((n < 1) ? 2 : n);
@@ -113,7 +113,7 @@ public:
 
    /// Copy constructor.
    template < class S >
-   explicit DSVectorBase<R>(const SVectorBase<S>& old)
+   explicit DSVectorBase(const SVectorBase<S>& old)
       : theelem(0)
    {
       allocMem(old.size());
@@ -126,7 +126,7 @@ public:
    /** The redundancy with the copy constructor below is necessary since otherwise the compiler doesn't realize that it
     *  could use the more general one with S = R and generates a shallow copy constructor.
     */
-   DSVectorBase<R>(const DSVectorBase<R>& old)
+   DSVectorBase(const DSVectorBase<R>& old)
       : SVectorBase<R>()
       , theelem(0)
    {
@@ -138,7 +138,7 @@ public:
 
    /// Copy constructor.
    template < class S >
-   DSVectorBase<R>(const DSVectorBase<S>& old)
+   DSVectorBase(const DSVectorBase<S>& old)
       : SVectorBase<R>()
       , theelem(0)
    {
@@ -150,11 +150,11 @@ public:
 
    /// Copy constructor.
    template < class S >
-   explicit DSVectorBase<R>(const VectorBase<S>& vec);
+   explicit DSVectorBase(const VectorBase<S>& vec);
 
    /// Copy constructor.
    template < class S >
-   explicit DSVectorBase<R>(const SSVectorBase<S>& old);
+   explicit DSVectorBase(const SSVectorBase<S>& old);
 
    /// Assignment operator.
    template < class S >
@@ -206,7 +206,7 @@ public:
    DSVectorBase<R>& operator=(const SSVectorBase<S>& vec);
 
    /// Destructor.
-   virtual ~DSVectorBase<R>()
+   virtual ~DSVectorBase()
    {
       if(theelem)
       {

--- a/src/soplex/islist.h
+++ b/src/soplex/islist.h
@@ -476,7 +476,7 @@ public:
    }
 
    /// Assignment operator and copy constructor should be deleted to avoid memory problems
-   IsList<T> (const IsList<T>&) = delete;
+   IsList (const IsList<T>&) = delete;
    IsList<T>& operator=(const IsList<T>& old) = delete;
 
    /// destructor

--- a/src/soplex/lpcolbase.h
+++ b/src/soplex/lpcolbase.h
@@ -77,7 +77,7 @@ public:
    /// Default constructor.
    /** Construct LPColBase with a column vector ready for taking \p defDim nonzeros.
     */
-   explicit LPColBase<R>(int defDim = 0)
+   explicit LPColBase(int defDim = 0)
       : up(R(infinity)), low(0), object(0), vec(defDim)
    {
       assert(isConsistent());
@@ -87,7 +87,7 @@ public:
    /*  Construct LPColBase with the given objective value \p obj, a column %vector \p vec, upper bound \p upper and
     *  lower bound \p lower.
     */
-   LPColBase<R>(const R& p_obj, const SVectorBase<R>& p_vector, const R& p_upper, const R& p_lower)
+   LPColBase(const R& p_obj, const SVectorBase<R>& p_vector, const R& p_upper, const R& p_lower)
       : up(p_upper), low(p_lower), object(p_obj), vec(p_vector)
    {
       assert(isConsistent());
@@ -108,7 +108,7 @@ public:
    }
 
    /// Copy constructor.
-   LPColBase<R>(const LPColBase<R>& old)
+   LPColBase(const LPColBase<R>& old)
       : up(old.up), low(old.low), object(old.object), vec(old.vec)
    {
       assert(isConsistent());
@@ -116,7 +116,7 @@ public:
 
    /// Copy constructor.
    template < class S >
-   LPColBase<R>(const LPColBase<S>& old)
+   LPColBase(const LPColBase<S>& old)
       : up(old.up), low(old.low), object(old.object), vec(old.vec)
    {
       assert(isConsistent());

--- a/src/soplex/lpcolsetbase.h
+++ b/src/soplex/lpcolsetbase.h
@@ -600,7 +600,7 @@ public:
     *  number of columns to the LPColSetBase, which may result in automated memory realllocation.
    */
    explicit
-   LPColSetBase<R>(int pmax = -1, int pmemmax = -1)
+   LPColSetBase(int pmax = -1, int pmemmax = -1)
       : SVSetBase<R>(pmax, pmemmax), low(0), up(0), object(0), scaleExp(0)
    {
       assert(isConsistent());
@@ -642,7 +642,7 @@ public:
    }
 
    /// Copy constructor.
-   LPColSetBase<R>(const LPColSetBase<R>& rs)
+   LPColSetBase(const LPColSetBase<R>& rs)
       : SVSetBase<R>(rs)
       , low(rs.low)
       , up(rs.up)
@@ -654,7 +654,7 @@ public:
 
    /// Copy constructor.
    template < class S >
-   LPColSetBase<R>(const LPColSetBase<S>& rs)
+   LPColSetBase(const LPColSetBase<S>& rs)
       : SVSetBase<R>(rs)
       , low(rs.low)
       , up(rs.up)
@@ -665,7 +665,7 @@ public:
    }
 
    /// Destructor.
-   virtual ~LPColSetBase<R>()
+   virtual ~LPColSetBase()
    {}
 
    ///@}

--- a/src/soplex/lprowbase.h
+++ b/src/soplex/lprowbase.h
@@ -93,7 +93,7 @@ public:
    ///@{
 
    /// Constructs LPRowBase with a vector ready to hold \p defDim nonzeros.
-   explicit LPRowBase<R>(int defDim = 0)
+   explicit LPRowBase(int defDim = 0)
       : left(0), right(R(infinity)), object(0), vec(defDim)
    {
       assert(isConsistent());
@@ -114,7 +114,7 @@ public:
    }
 
    /// Copy constructor.
-   LPRowBase<R>(const LPRowBase<R>& row)
+   LPRowBase(const LPRowBase<R>& row)
       : left(row.left), right(row.right), object(row.object), vec(row.vec)
    {
       assert(isConsistent());
@@ -122,21 +122,21 @@ public:
 
    /// Copy constructor.
    template < class S >
-   LPRowBase<R>(const LPRowBase<S>& row)
+   LPRowBase(const LPRowBase<S>& row)
       : left(row.left), right(row.right), object(row.object), vec(row.vec)
    {
       assert(isConsistent());
    }
 
    /// Constructs LPRowBase with the given left-hand side, right-hand side and rowVector.
-   LPRowBase<R>(const R& p_lhs, const SVectorBase<R>& p_rowVector, const R& p_rhs, const R& p_obj = 0)
+   LPRowBase(const R& p_lhs, const SVectorBase<R>& p_rowVector, const R& p_rhs, const R& p_obj = 0)
       : left(p_lhs), right(p_rhs), object(p_obj), vec(p_rowVector)
    {
       assert(isConsistent());
    }
 
    /// Constructs LPRowBase from passed \p rowVector, \p type and \p value.
-   LPRowBase<R>(const SVectorBase<R>& p_rowVector, Type p_type, const R& p_value, const R& p_obj = 0)
+   LPRowBase(const SVectorBase<R>& p_rowVector, Type p_type, const R& p_value, const R& p_obj = 0)
       : object(p_obj), vec(p_rowVector)
    {
       switch(p_type)

--- a/src/soplex/lprowsetbase.h
+++ b/src/soplex/lprowsetbase.h
@@ -690,7 +690,7 @@ public:
     *  rows to the LPRowSetBase, which may result in automated memory realllocation.
     */
    explicit
-   LPRowSetBase<R>(int pmax = -1, int pmemmax = -1)
+   LPRowSetBase(int pmax = -1, int pmemmax = -1)
       : SVSetBase<R>(pmax, pmemmax), left(0), right(0), object(0), scaleExp(0)
    {
       assert(isConsistent());
@@ -732,7 +732,7 @@ public:
    }
 
    /// Copy constructor.
-   LPRowSetBase<R>(const LPRowSetBase<R>& rs)
+   LPRowSetBase(const LPRowSetBase<R>& rs)
       : SVSetBase<R>(rs)
       , left(rs.left)
       , right(rs.right)
@@ -744,7 +744,7 @@ public:
 
    /// Copy constructor.
    template < class S >
-   LPRowSetBase<R>(const LPRowSetBase<S>& rs)
+   LPRowSetBase(const LPRowSetBase<S>& rs)
       : SVSetBase<R>(rs)
       , left(rs.left)
       , right(rs.right)
@@ -755,7 +755,7 @@ public:
    }
 
    /// Destructor.
-   virtual ~LPRowSetBase<R>()
+   virtual ~LPRowSetBase()
    {}
 
    ///@}

--- a/src/soplex/slufactor.h
+++ b/src/soplex/slufactor.h
@@ -309,13 +309,13 @@ public:
    /**@name Constructors / Destructors */
    ///@{
    /// default constructor.
-   SLUFactor<R>();
+   SLUFactor();
    /// assignment operator.
    SLUFactor<R>& operator=(const SLUFactor<R>& old);
    /// copy constructor.
-   SLUFactor<R>(const SLUFactor<R>& old);
+   SLUFactor(const SLUFactor<R>& old);
    /// destructor.
-   virtual ~SLUFactor<R>();
+   virtual ~SLUFactor();
    /// clone function for polymorphism
    inline virtual SLinSolver<R>* clone() const
    {

--- a/src/soplex/slufactor.hpp
+++ b/src/soplex/slufactor.hpp
@@ -1355,7 +1355,7 @@ void SLUFactor<R>::freeAll()
 }
 
 template <class R>
-SLUFactor<R>::~SLUFactor<R>()
+SLUFactor<R>::~SLUFactor()
 {
    freeAll();
 }

--- a/src/soplex/solbase.h
+++ b/src/soplex/solbase.h
@@ -241,7 +241,7 @@ private:
    unsigned int _hasDualFarkas: 1;
 
    /// default constructor only for friends
-   SolBase<R>()
+   SolBase()
       : _objVal(0)
    {
       invalidate();

--- a/src/soplex/spxbasis.h
+++ b/src/soplex/spxbasis.h
@@ -967,13 +967,13 @@ public:
    /**@name Constructors / Destructors */
    ///@{
    /// default constructor.
-   SPxBasisBase<R>(Timer::TYPE ttype = Timer::USER_TIME);
+   SPxBasisBase(Timer::TYPE ttype = Timer::USER_TIME);
    /// copy constructor
-   SPxBasisBase<R>(const SPxBasisBase<R>& old);
+   SPxBasisBase(const SPxBasisBase<R>& old);
    /// assignment operator
    SPxBasisBase<R>& operator=(const SPxBasisBase<R>& rhs);
    /// destructor.
-   virtual ~SPxBasisBase<R>();
+   virtual ~SPxBasisBase();
    ///@}
 
 

--- a/src/soplex/spxbasis.hpp
+++ b/src/soplex/spxbasis.hpp
@@ -1391,7 +1391,7 @@ SPxBasisBase<R>::SPxBasisBase(const SPxBasisBase<R>& old)
 }
 
 template <class R>
-SPxBasisBase<R>::~SPxBasisBase<R>()
+SPxBasisBase<R>::~SPxBasisBase()
 {
 
    assert(!freeSlinSolver || factor != 0);

--- a/src/soplex/spxlpbase.h
+++ b/src/soplex/spxlpbase.h
@@ -2806,7 +2806,7 @@ public:
    ///@{
 
    /// Default constructor.
-   SPxLPBase<R>()
+   SPxLPBase()
    {
       SPxLPBase<R>::clear(); // clear is virtual.
 
@@ -2814,11 +2814,11 @@ public:
    }
 
    /// Destructor.
-   virtual ~SPxLPBase<R>()
+   virtual ~SPxLPBase()
    {}
 
    /// Copy constructor.
-   SPxLPBase<R>(const SPxLPBase<R>& old)
+   SPxLPBase(const SPxLPBase<R>& old)
       : LPRowSetBase<R>(old)
       , LPColSetBase<R>(old)
       , thesense(old.thesense)
@@ -2832,7 +2832,7 @@ public:
 
    /// Copy constructor.
    template < class S >
-   SPxLPBase<R>(const SPxLPBase<S>& old)
+   SPxLPBase(const SPxLPBase<S>& old)
       : LPRowSetBase<R>(old)
       , LPColSetBase<R>(old)
       , thesense(old.thesense == SPxLPBase<S>::MINIMIZE ? SPxLPBase<R>::MINIMIZE : SPxLPBase<R>::MAXIMIZE)

--- a/src/soplex/ssvectorbase.h
+++ b/src/soplex/ssvectorbase.h
@@ -668,7 +668,7 @@ public:
    ///@{
 
    /// Default constructor.
-   explicit SSVectorBase<R>(int p_dim, R p_eps = Param::epsilon())
+   explicit SSVectorBase(int p_dim, R p_eps = Param::epsilon())
       : VectorBase<R>(p_dim)
       , IdxSet()
       , setupStatus(true)
@@ -683,7 +683,7 @@ public:
 
    /// Copy constructor.
    template < class S >
-   SSVectorBase<R>(const SSVectorBase<S>& vec)
+   SSVectorBase(const SSVectorBase<S>& vec)
       : VectorBase<R>(vec)
       , IdxSet()
       , setupStatus(vec.setupStatus)
@@ -700,7 +700,7 @@ public:
    /** The redundancy with the copy constructor below is necessary since otherwise the compiler doesn't realize that it
     *  could use the more general one with S = R and generates a shallow copy constructor.
     */
-   SSVectorBase<R>(const SSVectorBase<R>& vec)
+   SSVectorBase(const SSVectorBase<R>& vec)
       : VectorBase<R>(vec)
       , IdxSet()
       , setupStatus(vec.setupStatus)
@@ -715,7 +715,7 @@ public:
 
    /// Constructs nonsetup copy of \p vec.
    template < class S >
-   explicit SSVectorBase<R>(const VectorBase<S>& vec, R eps = Param::epsilon())
+   explicit SSVectorBase(const VectorBase<S>& vec, R eps = Param::epsilon())
       : VectorBase<R>(vec)
       , IdxSet()
       , setupStatus(false)
@@ -890,7 +890,7 @@ public:
    }
 
    /// destructor
-   ~SSVectorBase<R>()
+   ~SSVectorBase()
    {
       if(idx)
          spx_free(idx);

--- a/src/soplex/svectorbase.h
+++ b/src/soplex/svectorbase.h
@@ -60,13 +60,13 @@ public:
    }
 
    template < class S >
-   Nonzero<R>(const Nonzero<S>& vec)
+   Nonzero(const Nonzero<S>& vec)
       : val(vec.val)
       , idx(vec.idx)
    {
    }
 
-   Nonzero<R>()
+   Nonzero()
       : val()
       , idx(0)
    {
@@ -622,12 +622,12 @@ public:
     *  beginning of the memory block. Once this memory has been passed, it shall not be modified until the SVectorBase
     *  is no longer used.
     */
-   explicit SVectorBase<R>(int n = 0, Nonzero<R>* p_mem = 0)
+   explicit SVectorBase(int n = 0, Nonzero<R>* p_mem = 0)
    {
       setMem(n, p_mem);
    }
 
-   SVectorBase<R>(const SVectorBase<R>& sv) = default;
+   SVectorBase(const SVectorBase<R>& sv) = default;
 
    /// Assignment operator.
    template < class S >

--- a/src/soplex/svsetbase.h
+++ b/src/soplex/svsetbase.h
@@ -996,7 +996,7 @@ public:
 
    /// Default constructor.
    explicit
-   SVSetBase<R>(int pmax = -1, int pmemmax = -1, double pfac = 1.1, double pmemFac = 1.2)
+   SVSetBase(int pmax = -1, int pmemmax = -1, double pfac = 1.1, double pmemFac = 1.2)
       : SVSetBaseArray(0, (pmemmax > 0) ? pmemmax : 8 * ((pmax > 0) ? pmax : 8), pmemFac)
       , set((pmax > 0) ? pmax : 8)
       , unusedMem(0)
@@ -1007,7 +1007,7 @@ public:
    }
 
    /// Destructor
-   virtual ~SVSetBase<R>()
+   virtual ~SVSetBase()
    {}
 
    /// Assignment operator.
@@ -1063,7 +1063,7 @@ public:
    }
 
    /// Copy constructor.
-   SVSetBase<R>(const SVSetBase<R>& old)
+   SVSetBase(const SVSetBase<R>& old)
       : SVSetBaseArray()
       , unusedMem(old.unusedMem)
       , numUnusedMemUpdates(old.numUnusedMemUpdates)
@@ -1076,7 +1076,7 @@ public:
 
    /// Copy constructor.
    template < class S >
-   SVSetBase<R>(const SVSetBase<S>& old)
+   SVSetBase(const SVSetBase<S>& old)
       : SVSetBaseArray()
       , unusedMem(old.unusedMem)
       , numUnusedMemUpdates(old.numUnusedMemUpdates)

--- a/src/soplex/unitvectorbase.h
+++ b/src/soplex/unitvectorbase.h
@@ -87,7 +87,7 @@ public:
    ///@{
    /// construct \c i 'th unit vector.
    explicit
-   UnitVectorBase<R>(int i = 0)
+   UnitVectorBase(int i = 0)
       : SVectorBase<R>(1, &themem)
    {
       // coverity[callee_ptr_arith]
@@ -96,7 +96,7 @@ public:
       assert(isConsistent());
    }
    ///  copy constructor
-   UnitVectorBase<R>(const UnitVectorBase<R>& rhs)
+   UnitVectorBase(const UnitVectorBase<R>& rhs)
       : SVectorBase<R>(1, &themem)
    {
       themem = rhs.themem;
@@ -118,7 +118,7 @@ public:
       return *this;
    }
    /// destructor
-   ~UnitVectorBase<R>()
+   ~UnitVectorBase()
    {}
    ///@}
 

--- a/src/soplex/updatevector.h
+++ b/src/soplex/updatevector.h
@@ -77,7 +77,7 @@ public:
    ///@{
    /// default constructor.
    explicit
-   UpdateVector<R>(int p_dim /*=0*/, R p_eps /*=1e-16*/)
+   UpdateVector(int p_dim /*=0*/, R p_eps /*=1e-16*/)
       : VectorBase<R> (p_dim)
       , theval(0)
       , thedelta(p_dim, p_eps)
@@ -85,10 +85,10 @@ public:
       assert(isConsistent());
    }
    ///
-   ~UpdateVector<R>()
+   ~UpdateVector()
    {}
    /// copy constructor
-   UpdateVector<R>(const UpdateVector<R>&);
+   UpdateVector(const UpdateVector<R>&);
    /// assignment from VectorBase<R>
    UpdateVector<R>& operator=(const VectorBase<R>& rhs)
    {

--- a/src/soplex/vectorbase.h
+++ b/src/soplex/vectorbase.h
@@ -114,20 +114,20 @@ public:
     */
 
    // Default constructor
-   VectorBase<R>()
+   VectorBase()
    {
       // Default constructor
       ;
    }
 
    // Construct from pointer, copies the values into the VectorBase
-   VectorBase<R>(int dimen, R* p_val)
+   VectorBase(int dimen, R* p_val)
    {
       val.assign(p_val, p_val + dimen);
    }
 
    // do not convert int to empty vectorbase
-   explicit VectorBase<R>(int p_dimen)
+   explicit VectorBase(int p_dimen)
    {
       val.resize(p_dimen);
    }
@@ -135,18 +135,18 @@ public:
    // Constructing an element (usually involving casting Real to Rational and
    // vice versa.)
    template <typename S>
-   VectorBase<R>(const VectorBase<S>& vec)
+   VectorBase(const VectorBase<S>& vec)
    {
       this->operator=(vec);
    }
 
    // The move constructor
-   VectorBase<R>(const VectorBase<R>&& vec)noexcept: val(std::move(vec.val))
+   VectorBase(const VectorBase<R>&& vec)noexcept: val(std::move(vec.val))
    {
    }
 
    // Copy constructor
-   VectorBase<R>(const VectorBase<R>& vec): val(vec.val)
+   VectorBase(const VectorBase<R>& vec): val(vec.val)
    {
    }
 


### PR DESCRIPTION
Currently SoPlex cannot be used as a library when compiling with c++20, since adding the template parameter to the constructor of a templated class is no longer permitted (https://cplusplus.github.io/CWG/issues/2237.html), but SoPlex uses this in several header files.
This pull request removes redundant template parameters from the header files. 