### PR TITLE
Use GNUInstallDirs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@
 function(setLibProperties targetname outputname)
     set_target_properties(${targetname} PROPERTIES
         OUTPUT_NAME ${outputname}
-        MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+	MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 endfunction(setLibProperties)
 
 include(GNUInstallDirs)
@@ -208,7 +208,7 @@ add_executable(example EXCLUDE_FROM_ALL example.cpp)
 target_link_libraries(example libsoplex)
 
 # set the install rpath to the installed destination
-set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 # install the header files of soplex
 install(FILES ${headers} ${PROJECT_BINARY_DIR}/soplex/config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/soplex)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,8 @@ function(setLibProperties targetname outputname)
         MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endfunction(setLibProperties)
 
+include(GNUInstallDirs)
+
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(sources
@@ -209,15 +211,15 @@ target_link_libraries(example libsoplex)
 set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 # install the header files of soplex
-install(FILES ${headers} ${PROJECT_BINARY_DIR}/soplex/config.h DESTINATION include/soplex)
-install(FILES soplex.h soplex.hpp soplex_interface.h DESTINATION include)
+install(FILES ${headers} ${PROJECT_BINARY_DIR}/soplex/config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/soplex)
+install(FILES soplex.h soplex.hpp soplex_interface.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # install the binary and the library to appropriate lcoations and add them to an export group
 install(TARGETS soplex libsoplex libsoplex-pic libsoplexshared EXPORT soplex-targets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include)
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Add library targets to the build-tree export set
 export(TARGETS libsoplex libsoplex-pic libsoplexshared
@@ -243,7 +245,7 @@ configure_file(${PROJECT_SOURCE_DIR}/soplex-config.cmake.in
 
 # install the targets of the soplex export group and the config file so that other projects
 # can link easily against soplex
-install(EXPORT soplex-targets FILE soplex-targets.cmake DESTINATION lib/cmake/soplex)
+install(EXPORT soplex-targets FILE soplex-targets.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/soplex)
 install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/soplex-config.cmake"
 	           ${CMAKE_BINARY_DIR}/soplex-config-version.cmake
-	     DESTINATION lib/cmake/soplex)
+		   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/soplex)


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

Fixes multilib installation paths (e.g. `/usr/lib64` vs. `/usr/lib`) on some Linux distributions.

I’m not a CMake expert, and I haven’t attempted to test this on other platforms, but it seems to work for me.