### PR TITLE
Remove nondefinition declarations

### DIFF
--- a/src/soplex/spxweightpr.hpp
+++ b/src/soplex/spxweightpr.hpp
@@ -31,12 +31,6 @@
 namespace soplex
 {
 template <class R>
-void SPxWeightPR<R>::computeLeavePenalty(int start, int end);
-
-template <class R>
-bool SPxWeightPR<R>::isConsistent() const;
-
-template <class R>
 void SPxWeightPR<R>::setRep(typename SPxSolverBase<R>::Representation rep)
 {
    if(rep == SPxSolverBase<R>::ROW)


### PR DESCRIPTION
This PR fixes these errors when building gfan with soplex 6.0.4:
```
In file included from /usr/include/soplex/spxweightpr.h:192,
                 from src/lp_soplexcdd.cpp:15:
/usr/include/soplex/spxweightpr.hpp: At global scope:
/usr/include/soplex/spxweightpr.hpp:34:6: error: declaration of 'void soplex::SPxWeightPR<R>::computeLeavePenalty(int, int)' outside of class is not definition [-fpermissive]
   34 | void SPxWeightPR<R>::computeLeavePenalty(int start, int end);
      |      ^~~~~~~~~~~~~~
/usr/include/soplex/spxweightpr.hpp:37:6: error: declaration of 'virtual bool soplex::SPxWeightPR<R>::isConsistent() const' outside of class is not definition [-fpermissive]
   37 | bool SPxWeightPR<R>::isConsistent() const;
      |      ^~~~~~~~~~~~~~
```

Indeed, `computeLeavePenalty` and `isConsistent`  are both declared as class members already in spxweightpr.h, so redeclaring them without definitions doesn't accomplish anything.