### PR TITLE
Very minor fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ src/soplex/git_hash.cpp
 # common cache files and folders
 .vscode/
 .nfs*
+cmake-build-debug/
+.idea/
 # compile and release objecs
 *.[oa]
 bin/

--- a/src/soplex/spxlpbase_rational.hpp
+++ b/src/soplex/spxlpbase_rational.hpp
@@ -396,12 +396,12 @@ bool SPxLPBase<Rational>::readLPF(
    int k;
    int buf_size;
    int buf_pos;
-   char* buf;
-   char* tmp;
-   char* line;
-   char* s;
-   char* pos;
+   char* buf = NULL;
+   char* tmp = NULL;
+   char* line = NULL;
+   char* pos = NULL;
    char* pos_old = 0;
+   char* s;
 
    if(p_cnames)
       cnames = p_cnames;

--- a/src/soplexmain.cpp
+++ b/src/soplexmain.cpp
@@ -155,7 +155,7 @@ void checkSolutionReal(SoPlexBase<R>& soplex)
       if(soplex.getBoundViolation(boundviol, sumviol) && soplex.getRowViolation(rowviol, sumviol))
       {
          SPX_MSG_INFO1(soplex.spxout,
-                       R maxviol = boundviol > rowviol ? boundviol : rowviol;
+                       const R &maxviol = boundviol > rowviol ? boundviol : rowviol;
                        bool feasible = (maxviol <= soplex.realParam(SoPlexBase<R>::FEASTOL));
                        soplex.spxout << "Primal solution " << (feasible ? "feasible" : "infeasible")
                        << " in original problem (max. violation = " << std::scientific << maxviol
@@ -180,7 +180,7 @@ void checkSolutionReal(SoPlexBase<R>& soplex)
       if(soplex.getRedCostViolation(redcostviol, sumviol) && soplex.getDualViolation(dualviol, sumviol))
       {
          SPX_MSG_INFO1(soplex.spxout,
-                       R maxviol = redcostviol > dualviol ? redcostviol : dualviol;
+                       const R &maxviol = redcostviol > dualviol ? redcostviol : dualviol;
                        bool feasible = (maxviol <= soplex.realParam(SoPlexBase<R>::OPTTOL));
                        soplex.spxout << "Dual solution " << (feasible ? "feasible" : "infeasible")
                        << " in original problem (max. violation = " << std::scientific << maxviol
@@ -213,7 +213,7 @@ static void checkSolutionRational(SoPlexBase<R>& soplex)
             && soplex.getRowViolationRational(rowviol, sumviol))
       {
          SPX_MSG_INFO1(soplex.spxout,
-                       Rational maxviol = boundviol > rowviol ? boundviol : rowviol;
+                       const Rational &maxviol = boundviol > rowviol ? boundviol : rowviol;
                        bool feasible = (maxviol <= soplex.realParam(SoPlexBase<R>::FEASTOL));
                        soplex.spxout << "Primal solution " << (feasible ? "feasible" : "infeasible") <<
                        " in original problem (max. violation = " << maxviol << ").\n"
@@ -239,7 +239,7 @@ static void checkSolutionRational(SoPlexBase<R>& soplex)
             && soplex.getDualViolationRational(dualviol, sumviol))
       {
          SPX_MSG_INFO1(soplex.spxout,
-                       Rational maxviol = redcostviol > dualviol ? redcostviol : dualviol;
+                       const Rational &maxviol = redcostviol > dualviol ? redcostviol : dualviol;
                        bool feasible = (maxviol <= soplex.realParam(SoPlexBase<R>::OPTTOL));
                        soplex.spxout << "Dual solution " << (feasible ? "feasible" : "infeasible") <<
                        " in original problem (max. violation = " << maxviol << ").\n"


### PR DESCRIPTION
Some minor housekeeping fixes and improvements:

- [ensure strings to a NULL value before use](https://github.com/scipopt/soplex/commit/658ab44bd5bbd65cb6bdbadddee2b8a5fe039004) when in rational mode, as done in 1de95a8 for the real mode
- [add common cache directory editor directory to .gitignore](https://github.com/scipopt/soplex/commit/14340e494ae0c9cf32a215aa5b9425281a6e3dfc), namely for IntelliJ editors
- [avoid unnecessary copy of readonly value](https://github.com/scipopt/soplex/commit/70f9b376b100e0e1b5a6206bf3106d3d4aac5052)