### PR TITLE
Use std::copy to copy arrays

### DIFF
--- a/src/soplex/datahashtable.h
+++ b/src/soplex/datahashtable.h
@@ -28,7 +28,9 @@
 #ifndef _DATAHASHTABLE_H_
 #define _DATAHASHTABLE_H_
 
+#include <algorithm>
 #include <iostream>
+#include <iterator>
 #include <assert.h>
 #include <limits.h>
 
@@ -358,7 +360,7 @@ public:
       m_memfactor = base.m_memfactor;
       m_used = base.m_used;
       m_hashsize = base.m_hashsize;
-      primes = base.primes;
+      std::copy(std::begin(base.primes), std::end(base.primes), std::begin(primes));
       nprimes = base.nprimes;
 
       assert(m_memfactor > 1.0);
@@ -373,9 +375,9 @@ public:
       , m_memfactor(base.m_memfactor)
       , m_used(base.m_used)
       , m_hashsize(base.m_hashsize)
-      , primes(base.primes)
       , nprimes(base.nprimes)
    {
+      std::copy(std::begin(base.primes), std::end(base.primes), std::begin(primes));
       assert(m_memfactor > 1.0);
       assert(isConsistent());
    }


### PR DESCRIPTION
GCC 14 emits this error when building soplex 6.0.4:
```
In file included from /builddir/build/BUILD/soplex-release-604/src/soplex/nameset.h:35,
                 from /builddir/build/BUILD/soplex-release-604/src/soplex/nameset.cpp:27:
/builddir/build/BUILD/soplex-release-604/src/soplex/datahashtable.h: In member function ‘soplex::DataHashTable<HashItem, Info>& soplex::DataHashTable<HashItem, Info>::operator=(const soplex::DataHashTable<HashItem, Info>&)’:
/builddir/build/BUILD/soplex-release-604/src/soplex/datahashtable.h:361:14: error: invalid array assignment
  361 |       primes = base.primes;
      |       ~~~~~~~^~~~~~~~~~~~~
```

Use std::copy instead to avoid the error.