### PR TITLE
Get single or set of row's activity

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@ interface & parameters:
   SoPlex_getNumIterations(), SoPlex_changeRowLhsReal(), SoPlex_changeRowRhsReal(), SoPlex_changeRangeReal(),
   SoPlex_changeRowRangeReal(), SoPlex_changeLowerReal(), SoPlex_changeVarLowerReal(), SoPlex_getLowerReal(),
   SoPlex_getObjReal(), SoPlex_changeUpperReal()
+- add new functions to soplex.h: getRowActivity(), getRowActivityRational(), getRowsActivity(), getRowsActivityReal(),
+  getRowsActivityRational() supported by the addition of computePrimalActivity() in spxlpbase.h
 
 performance:
 
@@ -28,6 +30,7 @@ code quality:
 - rewrite all preprocessor-defines to be unambiguous by prepending a `SPX`, e.g., `MSG_ERROR` is now `SPX_MSG_ERROR`.
 - rework soplex debug messages to use SFINAE, since they no longer worked properly after switching to header-only
 - add .lp instances to ctest
+- avoid deprecated definition of implicit copy constructor for 'SPxException', 'SLinSolver', 'SLinSolverRational'
 
 fixed bugs:
 - fix unset tolerances for simplifier and ratio tester plugins in soplex' copy constructor

--- a/src/soplex.h
+++ b/src/soplex.h
@@ -663,6 +663,20 @@ public:
    bool getPrimalReal(R* p_vector, int size);      // For SCIP compatibility
    bool getPrimalRational(VectorRational& vector);
 
+   /// Get the value for the \p i 'th row given the current primal solution
+   bool getRowPrimalValue(R& value, int i);
+   bool getRowPrimalValueRational(Rational& value, int i);
+
+   /// Get the value for the row with indices in \p indices given the current primal solution
+   bool getRowsPrimalValue(const std::set<int>& indices, VectorBase<R>& vector);
+   bool getRowsPrimalValueReal(const std::set<int>& indices, R* p_vector, int i);
+   bool getRowsPrimalValueRational(const std::set<int>& indices, VectorRational& vector);
+
+   /// Get the value for all rows given the current primal solution
+   bool getRowsPrimalValue(VectorBase<R>& vector);
+   bool getRowsPrimalValueReal(R* p_vector, int i);
+   bool getRowsPrimalValueRational(VectorRational& vector);
+
    /// gets the vector of slack values if available; returns true on success
    bool getSlacksReal(VectorBase<R>& vector);
    bool getSlacksReal(R* p_vector, int dim);

--- a/src/soplex.h
+++ b/src/soplex.h
@@ -664,8 +664,8 @@ public:
    bool getPrimalRational(VectorRational& vector);
 
    /// Get the value for the \p i 'th row given the current primal solution
-   bool getRowPrimalValue(R& value, int i);
-   bool getRowPrimalValueRational(Rational& value, int i);
+   bool getRowPrimalValue(int i, R& value);
+   bool getRowPrimalValueRational(int i, Rational& value);
 
    /// Get the value for the row with indices in \p indices given the current primal solution
    bool getRowsPrimalValue(const std::set<int>& indices, VectorBase<R>& vector);

--- a/src/soplex.h
+++ b/src/soplex.h
@@ -668,9 +668,9 @@ public:
    bool getRowPrimalValueRational(int i, Rational& value);
 
    /// Get the value for the row with indices in \p indices given the current primal solution
-   bool getRowsPrimalValue(const std::set<int>& indices, VectorBase<R>& vector);
-   bool getRowsPrimalValueReal(const std::set<int>& indices, R* p_vector, int i);
-   bool getRowsPrimalValueRational(const std::set<int>& indices, VectorRational& vector);
+   bool getRowsPrimalValue(const std::vector<int>& indices, VectorBase<R>& vector);
+   bool getRowsPrimalValueReal(const std::vector<int>& indices, R* p_vector, int i);
+   bool getRowsPrimalValueRational(const std::vector<int>& indices, VectorRational& vector);
 
    /// Get the value for all rows given the current primal solution
    bool getRowsPrimalValue(VectorBase<R>& vector);

--- a/src/soplex.h
+++ b/src/soplex.h
@@ -663,16 +663,19 @@ public:
    bool getPrimalReal(R* p_vector, int size);      // For SCIP compatibility
    bool getPrimalRational(VectorRational& vector);
 
-   /// Get the value for the \p i 'th row given the current primal solution
+   /// gets the value for the \p i 'th row given the current primal solution
    bool getRowPrimalValue(int i, R& value);
    bool getRowPrimalValueRational(int i, Rational& value);
 
-   /// Get the value for the row with indices in \p indices given the current primal solution
+   /// gets the value for the row with indices in \p indices given the current primal solution.
+   /// \p vector must have the same size as the total number of rows.
+   /// Al other elements of \p vector are left unchanged
    bool getRowsPrimalValue(const std::vector<int>& indices, VectorBase<R>& vector);
    bool getRowsPrimalValueReal(const std::vector<int>& indices, R* p_vector, int i);
    bool getRowsPrimalValueRational(const std::vector<int>& indices, VectorRational& vector);
 
-   /// Get the value for all rows given the current primal solution
+   /// gets the value for all rows given the current primal solution.
+   /// \p vector must have the same size as the total number of rows
    bool getRowsPrimalValue(VectorBase<R>& vector);
    bool getRowsPrimalValueReal(R* p_vector, int i);
    bool getRowsPrimalValueRational(VectorRational& vector);

--- a/src/soplex.h
+++ b/src/soplex.h
@@ -664,21 +664,21 @@ public:
    bool getPrimalRational(VectorRational& vector);
 
    /// gets the value for the \p i 'th row given the current primal solution
-   bool getRowPrimalValue(int i, R& value);
-   bool getRowPrimalValueRational(int i, Rational& value);
+   bool getRowActivity(int i, R& value);
+   bool getRowActivityRational(int i, Rational& value);
 
    /// gets the value for the row with indices in \p indices given the current primal solution.
    /// \p vector must have the same size as the total number of rows.
    /// Al other elements of \p vector are left unchanged
-   bool getRowsPrimalValue(const std::vector<int>& indices, VectorBase<R>& vector);
-   bool getRowsPrimalValueReal(const std::vector<int>& indices, R* p_vector, int i);
-   bool getRowsPrimalValueRational(const std::vector<int>& indices, VectorRational& vector);
+   bool getRowsActivity(const std::vector<int>& indices, VectorBase<R>& vector);
+   bool getRowsActivityReal(const std::vector<int>& indices, R* p_vector, int dim);
+   bool getRowsActivityRational(const std::vector<int>& indices, VectorRational& vector);
 
    /// gets the value for all rows given the current primal solution.
    /// \p vector must have the same size as the total number of rows
-   bool getRowsPrimalValue(VectorBase<R>& vector);
-   bool getRowsPrimalValueReal(R* p_vector, int i);
-   bool getRowsPrimalValueRational(VectorRational& vector);
+   bool getRowsActivity(VectorBase<R>& vector);
+   bool getRowsActivityReal(R* p_vector, int dim);
+   bool getRowsActivityRational(VectorRational& vector);
 
    /// gets the vector of slack values if available; returns true on success
    bool getSlacksReal(VectorBase<R>& vector);

--- a/src/soplex.hpp
+++ b/src/soplex.hpp
@@ -3885,7 +3885,7 @@ bool SoPlexBase<R>::getRowPrimalValueRational(int i, Rational& value) {
 }
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValue(const std::set<int>& indices, VectorBase<R>& vector) {
+bool SoPlexBase<R>::getRowsPrimalValue(const std::vector<int>& indices, VectorBase<R>& vector) {
   if(_realLP != 0 && hasSol())
   {
     assert(vector.dim() >= static_cast<int>(indices.size()));
@@ -3899,7 +3899,7 @@ bool SoPlexBase<R>::getRowsPrimalValue(const std::set<int>& indices, VectorBase<
 
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValueReal(const std::set<int>& indices, R* p_vector, int i) {
+bool SoPlexBase<R>::getRowsPrimalValueReal(const std::vector<int>& indices, R* p_vector, int i) {
   if(_realLP != 0 && hasSol())
   {
     assert(i >= static_cast<int>(indices.size()));
@@ -3915,7 +3915,7 @@ bool SoPlexBase<R>::getRowsPrimalValueReal(const std::set<int>& indices, R* p_ve
 
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValueRational(const std::set<int>& indices, VectorRational& vector) {
+bool SoPlexBase<R>::getRowsPrimalValueRational(const std::vector<int>& indices, VectorRational& vector) {
   if(_rationalLP != 0 && hasSol())
   {
     assert(vector.dim() >= static_cast<int>(indices.size()));

--- a/src/soplex.hpp
+++ b/src/soplex.hpp
@@ -3861,7 +3861,7 @@ bool SoPlexBase<R>::getPrimalRational(VectorBase<Rational>& vector)
 }
 
 template <class R>
-bool SoPlexBase<R>::getRowPrimalValue(R& value, int i) {
+bool SoPlexBase<R>::getRowPrimalValue(int i, R& value) {
   if(_realLP != 0 && hasSol())
   {
     _syncRealSolution();
@@ -3873,7 +3873,7 @@ bool SoPlexBase<R>::getRowPrimalValue(R& value, int i) {
 }
 
 template <class R>
-bool SoPlexBase<R>::getRowPrimalValueRational(Rational& value, int i) {
+bool SoPlexBase<R>::getRowPrimalValueRational(int i, Rational& value) {
   if(_rationalLP != 0 && hasSol())
   {
     _syncRationalSolution();

--- a/src/soplex.hpp
+++ b/src/soplex.hpp
@@ -3860,6 +3860,114 @@ bool SoPlexBase<R>::getPrimalRational(VectorBase<Rational>& vector)
       return false;
 }
 
+template <class R>
+bool SoPlexBase<R>::getRowPrimalValue(R& value, int i) {
+  if(_realLP != 0 && hasSol())
+  {
+    _syncRealSolution();
+    value = _realLP->computePrimalActivity(i, _solReal._primal, true);
+    return true;
+  }
+  else
+    return false;
+}
+
+template <class R>
+bool SoPlexBase<R>::getRowPrimalValueRational(Rational& value, int i) {
+  if(_rationalLP != 0 && hasSol())
+  {
+    _syncRationalSolution();
+    value = _rationalLP->computePrimalActivity(i, _solRational._primal);
+    return true;
+  }
+  else
+    return false;
+}
+
+template <class R>
+bool SoPlexBase<R>::getRowsPrimalValue(const std::set<int>& indices, VectorBase<R>& vector) {
+  if(_realLP != 0 && hasSol())
+  {
+    assert(vector.dim() >= static_cast<int>(indices.size()));
+    _syncRealSolution();
+    _realLP->computePrimalActivity(indices, _solReal._primal, vector, true);
+    return true;
+  }
+  else
+    return false;
+}
+
+
+template <class R>
+bool SoPlexBase<R>::getRowsPrimalValueReal(const std::set<int>& indices, R* p_vector, int i) {
+  if(_realLP != 0 && hasSol())
+  {
+    assert(i >= static_cast<int>(indices.size()));
+    _syncRealSolution();
+    VectorBase<R> vector(i);
+    _realLP->computePrimalActivity(indices, _solReal._primal, vector, true);
+    std::copy(vector.begin(), vector.end(), p_vector);
+    return true;
+  }
+  else
+    return false;
+}
+
+
+template <class R>
+bool SoPlexBase<R>::getRowsPrimalValueRational(const std::set<int>& indices, VectorRational& vector) {
+  if(_rationalLP != 0 && hasSol())
+  {
+    assert(vector.dim() >= static_cast<int>(indices.size()));
+    _syncRationalSolution();
+    _rationalLP->computePrimalActivity(indices, _solRational._primal, vector);
+    return true;
+  }
+  else
+    return false;
+}
+
+template <class R>
+bool SoPlexBase<R>::getRowsPrimalValue(VectorBase<R>& vector) {
+  if(_realLP != 0 && hasSol())
+  {
+    assert(vector.dim() >= numRows());
+    _syncRealSolution();
+    _realLP->computePrimalActivity(_solReal._primal, vector, true);
+    return true;
+  }
+  else
+    return false;
+}
+
+
+template <class R>
+bool SoPlexBase<R>::getRowsPrimalValueReal(R* p_vector, int i) {
+  if(_realLP != 0 && hasSol())
+  {
+    assert(i >= numRows());
+    _syncRealSolution();
+    VectorBase<R> vector(i);
+    _realLP->computePrimalActivity(_solReal._primal, vector, true);
+    std::copy(vector.begin(), vector.end(), p_vector);
+    return true;
+  }
+  else
+    return false;
+}
+
+template <class R>
+bool SoPlexBase<R>::getRowsPrimalValueRational(VectorRational& vector) {
+  if(_rationalLP != 0 && hasSol())
+  {
+    assert(vector.dim() >= numRows());
+    _syncRationalSolution();
+    _rationalLP->computePrimalActivity(_solRational._primal, vector);
+    return true;
+  }
+  else
+    return false;
+}
 
 /// gets the vector of slack values if available; returns true on success
 template <class R>

--- a/src/soplex.hpp
+++ b/src/soplex.hpp
@@ -3861,11 +3861,11 @@ bool SoPlexBase<R>::getPrimalRational(VectorBase<Rational>& vector)
 }
 
 template <class R>
-bool SoPlexBase<R>::getRowPrimalValue(int i, R& value) {
+bool SoPlexBase<R>::getRowActivity(int i, R& value) {
   if(_realLP != 0 && hasSol())
   {
     _syncRealSolution();
-    value = _realLP->computePrimalActivity(i, _solReal._primal, true);
+    value = _realLP->computePrimalActivity(i, _solReal._primal);
     return true;
   }
   else
@@ -3873,7 +3873,7 @@ bool SoPlexBase<R>::getRowPrimalValue(int i, R& value) {
 }
 
 template <class R>
-bool SoPlexBase<R>::getRowPrimalValueRational(int i, Rational& value) {
+bool SoPlexBase<R>::getRowActivityRational(int i, Rational& value) {
   if(_rationalLP != 0 && hasSol())
   {
     _syncRationalSolution();
@@ -3885,12 +3885,12 @@ bool SoPlexBase<R>::getRowPrimalValueRational(int i, Rational& value) {
 }
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValue(const std::vector<int>& indices, VectorBase<R>& vector) {
+bool SoPlexBase<R>::getRowsActivity(const std::vector<int>& indices, VectorBase<R>& vector) {
   if(_realLP != 0 && hasSol())
   {
     assert(vector.dim() >= static_cast<int>(indices.size()));
     _syncRealSolution();
-    _realLP->computePrimalActivity(indices, _solReal._primal, vector, true);
+    _realLP->computePrimalActivity(indices, _solReal._primal, vector);
     return true;
   }
   else
@@ -3899,13 +3899,13 @@ bool SoPlexBase<R>::getRowsPrimalValue(const std::vector<int>& indices, VectorBa
 
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValueReal(const std::vector<int>& indices, R* p_vector, int i) {
+bool SoPlexBase<R>::getRowsActivityReal(const std::vector<int>& indices, R* p_vector, int dim) {
   if(_realLP != 0 && hasSol())
   {
-    assert(i >= static_cast<int>(indices.size()));
+    assert(dim >= numRows());
     _syncRealSolution();
-    VectorBase<R> vector(i);
-    _realLP->computePrimalActivity(indices, _solReal._primal, vector, true);
+    VectorBase<R> vector(dim);
+    _realLP->computePrimalActivity(indices, _solReal._primal, vector);
     std::copy(vector.begin(), vector.end(), p_vector);
     return true;
   }
@@ -3915,7 +3915,7 @@ bool SoPlexBase<R>::getRowsPrimalValueReal(const std::vector<int>& indices, R* p
 
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValueRational(const std::vector<int>& indices, VectorRational& vector) {
+bool SoPlexBase<R>::getRowsActivityRational(const std::vector<int>& indices, VectorRational& vector) {
   if(_rationalLP != 0 && hasSol())
   {
     assert(vector.dim() >= static_cast<int>(indices.size()));
@@ -3928,12 +3928,12 @@ bool SoPlexBase<R>::getRowsPrimalValueRational(const std::vector<int>& indices, 
 }
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValue(VectorBase<R>& vector) {
+bool SoPlexBase<R>::getRowsActivity(VectorBase<R>& vector) {
   if(_realLP != 0 && hasSol())
   {
     assert(vector.dim() >= numRows());
     _syncRealSolution();
-    _realLP->computePrimalActivity(_solReal._primal, vector, true);
+    _realLP->computePrimalActivity(_solReal._primal, vector);
     return true;
   }
   else
@@ -3942,13 +3942,13 @@ bool SoPlexBase<R>::getRowsPrimalValue(VectorBase<R>& vector) {
 
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValueReal(R* p_vector, int i) {
+bool SoPlexBase<R>::getRowsActivityReal(R* p_vector, int dim) {
   if(_realLP != 0 && hasSol())
   {
-    assert(i >= numRows());
+    assert(dim >= numRows());
     _syncRealSolution();
-    VectorBase<R> vector(i);
-    _realLP->computePrimalActivity(_solReal._primal, vector, true);
+    VectorBase<R> vector(dim);
+    _realLP->computePrimalActivity(_solReal._primal, vector);
     std::copy(vector.begin(), vector.end(), p_vector);
     return true;
   }
@@ -3957,7 +3957,7 @@ bool SoPlexBase<R>::getRowsPrimalValueReal(R* p_vector, int i) {
 }
 
 template <class R>
-bool SoPlexBase<R>::getRowsPrimalValueRational(VectorRational& vector) {
+bool SoPlexBase<R>::getRowsActivityRational(VectorRational& vector) {
   if(_rationalLP != 0 && hasSol())
   {
     assert(vector.dim() >= numRows());

--- a/src/soplex.hpp
+++ b/src/soplex.hpp
@@ -1264,7 +1264,7 @@ bool SoPlexBase<R>::getRowViolation(R& maxviol, R& sumviol)
    assert(primal.dim() == numCols());
 
    VectorBase<R> activity(numRows());
-   _realLP->computePrimalActivity(primal, activity, true);
+   _realLP->computePrimalActivity(primal, activity);
    maxviol = 0.0;
    sumviol = 0.0;
 

--- a/src/soplex/exceptions.h
+++ b/src/soplex/exceptions.h
@@ -55,7 +55,7 @@ public:
    /** The constructor receives an optional string as an exception message.
     */
    SPxException(const std::string& m = "") : msg(m) {}
-   SPxException(SPxException&) = default;
+   SPxException(const SPxException&) = default;
    SPxException(SPxException&&) = default;
    /// destructor
    virtual ~SPxException() = default;

--- a/src/soplex/exceptions.h
+++ b/src/soplex/exceptions.h
@@ -56,14 +56,14 @@ public:
     */
    SPxException(const std::string& m = "") : msg(m) {}
    /// destructor
-   virtual ~SPxException() {}
+   virtual ~SPxException() = default;
    ///@}
 
    //----------------------------------------
    /**@name Access / modification */
    ///@{
    /// returns exception message
-   virtual const std::string what() const
+   virtual const std::string& what() const
    {
       return msg;
    }

--- a/src/soplex/exceptions.h
+++ b/src/soplex/exceptions.h
@@ -55,6 +55,8 @@ public:
    /** The constructor receives an optional string as an exception message.
     */
    SPxException(const std::string& m = "") : msg(m) {}
+   SPxException(SPxException&) = default;
+   SPxException(SPxException&&) = default;
    /// destructor
    virtual ~SPxException() = default;
    ///@}

--- a/src/soplex/slinsolver.h
+++ b/src/soplex/slinsolver.h
@@ -212,9 +212,12 @@ public:
    SLinSolver()
       : spxout(0)
    {}
+   /// copy constructor
+   SLinSolver(const SLinSolver&) = default;
+   /// move constructor
+   SLinSolver(SLinSolver&&) = default;
    /// destructor
-   virtual ~SLinSolver()
-   {}
+   virtual ~SLinSolver() = default;
    /// clone function for polymorphism
    virtual SLinSolver<R>* clone() const = 0;
    ///@}

--- a/src/soplex/slinsolver_rational.h
+++ b/src/soplex/slinsolver_rational.h
@@ -186,11 +186,13 @@ public:
    /**@name Constructors / Destructors */
    ///@{
    /// default constructor
-   SLinSolverRational()
-   {}
+   SLinSolverRational() = default;
+   /// copy constructor
+   SLinSolverRational(const SLinSolverRational&) = default;
+   /// move constructor
+   SLinSolverRational(SLinSolverRational&&) = default;
    /// destructor
-   virtual ~SLinSolverRational()
-   {}
+   virtual ~SLinSolverRational() = default;
    /// clone function for polymorphism
    virtual SLinSolverRational* clone() const = 0;
    ///@}

--- a/src/soplex/spxlpbase.h
+++ b/src/soplex/spxlpbase.h
@@ -37,6 +37,7 @@
 #include <assert.h>
 #include <iostream>
 #include <iomanip>
+#include <set>
 #include <typeinfo>
 
 #include "soplex/spxdefines.h"

--- a/src/soplex/spxlpbase.h
+++ b/src/soplex/spxlpbase.h
@@ -1946,7 +1946,8 @@ public:
    /// \p unscaled determines whether the returned data should be unscaled (if scaling was applied prior)
    virtual R computePrimalActivity(int i, const VectorBase<R>& primal, const bool unscaled = true) const;
 
-   /// Computes activity of the selected set of rows for a given primal vector; activity does not need to be zero
+   /// Computes activity of the selected set of rows for a given primal vector; activity does not need to be zero.
+   /// Only the elements with indices in \p ids are computed. The remaining elements of \p activity are not changed.
    /// @throw SPxInternalCodeException if the dimension of primal vector does not match number of columns or if the
    ///        dimension of the activity vector does not match the number of rows in the set
    /// \p unscaled determines whether the returned data should be unscaled (if scaling was applied prior)

--- a/src/soplex/spxlpbase.h
+++ b/src/soplex/spxlpbase.h
@@ -1941,6 +1941,18 @@ public:
    virtual void computePrimalActivity(const VectorBase<R>& primal, VectorBase<R>& activity,
                                       const bool unscaled = true) const;
 
+   /// Computes activity of the \p i 'th row for a given primal vector;
+   /// @throw SPxInternalCodeException if the dimension of primal vector does not match number of columns
+   /// \p unscaled determines whether the returned data should be unscaled (if scaling was applied prior)
+   virtual R computePrimalActivity(int i, const VectorBase<R>& primal, const bool unscaled = true) const;
+
+   /// Computes activity of the selected set of rows for a given primal vector; activity does not need to be zero
+   /// @throw SPxInternalCodeException if the dimension of primal vector does not match number of columns or if the
+   ///        dimension of the activity vector does not match the number of rows in the set
+   /// \p unscaled determines whether the returned data should be unscaled (if scaling was applied prior)
+   virtual void computePrimalActivity(const std::set<int>& ids, const VectorBase<R>& primal, VectorBase<R>& activity,
+                                      const bool unscaled = true) const;
+
    /// Updates activity of the rows for a given primal vector; activity does not need to be zero
    /// @throw SPxInternalCodeException if the dimension of primal vector does not match number of columns or if the
    ///        dimension of the activity vector does not match the number of rows

--- a/src/soplex/spxlpbase.h
+++ b/src/soplex/spxlpbase.h
@@ -37,7 +37,6 @@
 #include <assert.h>
 #include <iostream>
 #include <iomanip>
-#include <set>
 #include <typeinfo>
 
 #include "soplex/spxdefines.h"
@@ -1951,7 +1950,7 @@ public:
    /// @throw SPxInternalCodeException if the dimension of primal vector does not match number of columns or if the
    ///        dimension of the activity vector does not match the number of rows in the set
    /// \p unscaled determines whether the returned data should be unscaled (if scaling was applied prior)
-   virtual void computePrimalActivity(const std::set<int>& ids, const VectorBase<R>& primal, VectorBase<R>& activity,
+   virtual void computePrimalActivity(const std::vector<int>& ids, const VectorBase<R>& primal, VectorBase<R>& activity,
                                       const bool unscaled = true) const;
 
    /// Updates activity of the rows for a given primal vector; activity does not need to be zero

--- a/src/soplex/spxlpbase_rational.hpp
+++ b/src/soplex/spxlpbase_rational.hpp
@@ -81,6 +81,78 @@ void SPxLPBase<Rational>::computePrimalActivity(const VectorBase<Rational>& prim
 }
 
 template<> inline
+Rational SPxLPBase<Rational>::computePrimalActivity(int i, const VectorBase<Rational>& primal, const bool unscaled) const
+{
+   if(primal.dim() != nCols())
+   {
+      throw SPxInternalCodeException("XSPXLP01 Primal vector for computing row activity has wrong dimension");
+   }
+
+   int c;
+
+   for(c = 0; c < nCols() && primal[c] == 0; c++)
+      ;
+
+   if (c >= nCols())
+      return 0;
+
+   Rational rowActivity = colVector(c).value(i) * primal[c];
+   c++;
+
+   for(; c < nCols(); c++)
+   {
+      if(primal[c] != 0)
+      {
+        rowActivity += colVector(c).value(i) * primal[c];
+      }
+   }
+   return rowActivity;
+}
+
+template<> inline
+    void SPxLPBase<Rational>::computePrimalActivity(const std::set<int>& ids, const VectorBase<Rational>& primal,
+                                               VectorBase<Rational>& activity, const bool unscaled) const
+{
+  if(primal.dim() != nCols())
+  {
+    throw SPxInternalCodeException("XSPXLP01 Primal vector for computing row activity has wrong dimension");
+  }
+
+  if(activity.dim() != static_cast<int>(ids.size()))
+  {
+    throw SPxInternalCodeException("XSPXLP03 Activity vector computing row activity has wrong dimension");
+  }
+
+  int c;
+
+  for(c = 0; c < nCols() && primal[c] == 0; c++)
+    ;
+
+  if(c >= nCols())
+  {
+    activity.clear();
+    return;
+  }
+
+  for (const int i : ids)
+  {
+    activity[i] = colVector(c).value(i) * primal[c];
+  }
+  c++;
+
+  for(; c < nCols(); c++)
+  {
+    if(primal[c] != 0)
+    {
+      for (const int i : ids)
+      {
+        activity[i] += colVector(c).value(i) * primal[c];
+      }
+    }
+  }
+}
+
+template<> inline
 void SPxLPBase<Rational>::computeDualActivity(const VectorBase<Rational>& dual,
       VectorBase<Rational>& activity, const bool unscaled) const
 {

--- a/src/soplex/spxlpbase_rational.hpp
+++ b/src/soplex/spxlpbase_rational.hpp
@@ -96,14 +96,14 @@ Rational SPxLPBase<Rational>::computePrimalActivity(int i, const VectorBase<Rati
    if (c >= nCols())
       return 0;
 
-   Rational rowActivity = colVector(c).value(i) * primal[c];
+   Rational rowActivity = colVector(c)[i] * primal[c];
    c++;
 
    for(; c < nCols(); c++)
    {
       if(primal[c] != 0)
       {
-        rowActivity += colVector(c).value(i) * primal[c];
+        rowActivity += colVector(c)[i] * primal[c];
       }
    }
    return rowActivity;
@@ -136,7 +136,7 @@ template<> inline
 
   for (const int i : ids)
   {
-    activity[i] = colVector(c).value(i) * primal[c];
+    activity[i] = colVector(c)[i] * primal[c];
   }
   c++;
 
@@ -146,7 +146,7 @@ template<> inline
     {
       for (const int i : ids)
       {
-        activity[i] += colVector(c).value(i) * primal[c];
+        activity[i] += colVector(c)[i] * primal[c];
       }
     }
   }

--- a/src/soplex/spxlpbase_rational.hpp
+++ b/src/soplex/spxlpbase_rational.hpp
@@ -110,7 +110,7 @@ Rational SPxLPBase<Rational>::computePrimalActivity(int i, const VectorBase<Rati
 }
 
 template<> inline
-    void SPxLPBase<Rational>::computePrimalActivity(const std::set<int>& ids, const VectorBase<Rational>& primal,
+    void SPxLPBase<Rational>::computePrimalActivity(const std::vector<int>& ids, const VectorBase<Rational>& primal,
                                                VectorBase<Rational>& activity, const bool unscaled) const
 {
   if(primal.dim() != nCols())

--- a/src/soplex/spxlpbase_rational.hpp
+++ b/src/soplex/spxlpbase_rational.hpp
@@ -118,7 +118,7 @@ template<> inline
     throw SPxInternalCodeException("XSPXLP01 Primal vector for computing row activity has wrong dimension");
   }
 
-  if(activity.dim() != static_cast<int>(ids.size()))
+  if(activity.dim() != nRows())
   {
     throw SPxInternalCodeException("XSPXLP03 Activity vector computing row activity has wrong dimension");
   }
@@ -130,7 +130,10 @@ template<> inline
 
   if(c >= nCols())
   {
-    activity.clear();
+    for (const int i : ids)
+    {
+      activity[i] = 0;
+    }
     return;
   }
 

--- a/src/soplex/spxlpbase_real.hpp
+++ b/src/soplex/spxlpbase_real.hpp
@@ -173,7 +173,7 @@ void SPxLPBase<R>::computePrimalActivity(const std::vector<int> &ids, const Vect
   if(primal.dim() != nCols())
     throw SPxInternalCodeException("XSPXLP01 Primal vector for computing row activity has wrong dimension");
 
-  if(activity.dim() != static_cast<int>(ids.size()))
+  if(activity.dim() != nRows())
     throw SPxInternalCodeException("XSPXLP03 Activity vector computing row activity has wrong dimension");
 
   int c;
@@ -183,7 +183,10 @@ void SPxLPBase<R>::computePrimalActivity(const std::vector<int> &ids, const Vect
 
   if(c >= nCols())
   {
-    activity.clear();
+    for (const int i : ids)
+    {
+      activity[i] = 0;
+    }
     return;
   }
 
@@ -207,10 +210,7 @@ void SPxLPBase<R>::computePrimalActivity(const std::vector<int> &ids, const Vect
     if(primal[c] != 0)
     {
       if(unscaled && _isScaled)
-      {
         lp_scaler->getColUnscaled(*this, c, tmp);
-        activity.multAdd(primal[c], tmp);
-      }
       else
         tmp = colVector(c);
 

--- a/src/soplex/spxlpbase_real.hpp
+++ b/src/soplex/spxlpbase_real.hpp
@@ -167,7 +167,7 @@ R SPxLPBase<R>::computePrimalActivity(int i, const VectorBase<R>& primal, const 
 }
 
 template <class R> inline
-void SPxLPBase<R>::computePrimalActivity(const std::set<int> &ids, const VectorBase<R>& primal, VectorBase<R>& activity,
+void SPxLPBase<R>::computePrimalActivity(const std::vector<int> &ids, const VectorBase<R>& primal, VectorBase<R>& activity,
                                         const bool unscaled) const
 {
   if(primal.dim() != nCols())

--- a/src/soplex/spxlpbase_real.hpp
+++ b/src/soplex/spxlpbase_real.hpp
@@ -198,7 +198,7 @@ void SPxLPBase<R>::computePrimalActivity(const std::set<int> &ids, const VectorB
 
   for (const int i : ids)
   {
-    activity[i] = primal[c] *  tmp.value(i);
+    activity[i] = primal[c] *  tmp[i];
   }
   c++;
 
@@ -216,7 +216,7 @@ void SPxLPBase<R>::computePrimalActivity(const std::set<int> &ids, const VectorB
 
       for (const int i : ids)
       {
-        activity[i] += primal[c] * tmp.value(i);
+        activity[i] += primal[c] * tmp[i];
       }
     }
   }


### PR DESCRIPTION
## Major

- Added two commodity overloads on the method `computePrimalActivity` to selectively compute only the activity of a single row or selected rows.
- Added `getRowPrimalValue` along with several variations to the solver. The idea is to have a way to efficiently get the value of a row computed with the current primal solution.

## Minor

- Use default destructor definition in `SPxException` to avoid the warning: `warning: definition of implicit copy constructor for 'SPxException' is deprecated because it has a user-declared destructor [-Wdeprecated]`
- Use const reference instead of const copy for the `what()` getter in `SPxException`