### PR TITLE
Avoid reading uninitialized value

### DIFF
--- a/src/soplex.hpp
+++ b/src/soplex.hpp
@@ -713,6 +713,8 @@ SoPlexBase<R>::SoPlexBase(const SoPlexBase<R>& rhs)
    spx_alloc(_currentSettings);
    _currentSettings = new(_currentSettings) Settings();
 
+   _rationalLP = nullptr;
+
    // call assignment operator
    *this = rhs;
 }


### PR DESCRIPTION
I am seeing test segfaults on the Fedora aarch64 builders with soplex 7.0.0.  The reason is that the copy constructor for SoPlexBase calls `operator=`, which compares `_rationalLP` to `nullptr` at line 1546 of src/soplex.hpp, but the copy constructor did not initialize `_rationalLP`, so it contains arbitrary bytes.  On the `x86_64` builders, we always seem to get lucky; `_rationalLP` is filled with zeroes.  This PR ensures that is the case on all architectures.