### PR TITLE
rename verobsity enums to avoid DEBUG conflict on MacOS

### DIFF
--- a/src/soplex.hpp
+++ b/src/soplex.hpp
@@ -5998,27 +5998,27 @@ bool SoPlexBase<R>::setIntParam(const IntParam param, const int value, const boo
       switch(value)
       {
       case 0:
-         spxout.setVerbosity(SPxOut::ERROR);
+         spxout.setVerbosity(SPxOut::VERB_ERROR);
          break;
 
       case 1:
-         spxout.setVerbosity(SPxOut::WARNING);
+         spxout.setVerbosity(SPxOut::VERB_WARNING);
          break;
 
       case 2:
-         spxout.setVerbosity(SPxOut::DEBUG);
+         spxout.setVerbosity(SPxOut::VERB_DEBUG);
          break;
 
       case 3:
-         spxout.setVerbosity(SPxOut::INFO1);
+         spxout.setVerbosity(SPxOut::VERB_INFO1);
          break;
 
       case 4:
-         spxout.setVerbosity(SPxOut::INFO2);
+         spxout.setVerbosity(SPxOut::VERB_INFO2);
          break;
 
       case 5:
-         spxout.setVerbosity(SPxOut::INFO3);
+         spxout.setVerbosity(SPxOut::VERB_INFO3);
          break;
       }
 
@@ -10095,7 +10095,7 @@ typename SPxSolverBase<R>::Status SoPlexBase<R>::optimize(volatile bool* interru
    }
 
    SPX_MSG_INFO1(spxout, spxout << "\n";
-                 printShortStatistics(spxout.getStream(SPxOut::INFO1));
+                 printShortStatistics(spxout.getStream(SPxOut::VERB_INFO1));
                  spxout << "\n");
 
 

--- a/src/soplex/spxdefines.h
+++ b/src/soplex/spxdefines.h
@@ -31,7 +31,7 @@
  * \ref soplex::SPxOut::VERB_INFO3 "VERB_INFO3" are set.
  * If \c NDEBUG is not defined, the code within \#TRACE is used.
  * If \c SOPLEX_DEBUG is defined, the code within
- * \ref soplex::SPxOut::VERB_DEBUG "DEBUG" is also used.
+ * \ref soplex::SPxOut::VERB_DEBUG "VERB_DEBUG" is also used.
  *
  * If \c WITH_LONG_DOUBLE is defined, all Real numbers are of type
  * long double instead of just double.

--- a/src/soplex/spxdefines.h
+++ b/src/soplex/spxdefines.h
@@ -26,12 +26,12 @@
  * @brief Debugging, floating point type and parameter definitions.
  *
  * In optimized code with \c NDEBUG defined, only
- * \ref soplex::SPxOut::INFO1 "INFO1",
- * \ref soplex::SPxOut::INFO2 "INFO2", and
- * \ref soplex::SPxOut::INFO3 "INFO3" are set.
+ * \ref soplex::SPxOut::VERB_INFO1 "INFO1",
+ * \ref soplex::SPxOut::VERB_INFO2 "INFO2", and
+ * \ref soplex::SPxOut::VERB_INFO3 "INFO3" are set.
  * If \c NDEBUG is not defined, the code within \#TRACE is used.
  * If \c SOPLEX_DEBUG is defined, the code within
- * \ref soplex::SPxOut::DEBUG "DEBUG" is also used.
+ * \ref soplex::SPxOut::VERB_DEBUG "DEBUG" is also used.
  *
  * If \c WITH_LONG_DOUBLE is defined, all Real numbers are of type
  * long double instead of just double.
@@ -159,16 +159,16 @@ bool EQ(int a, int b);
 #define SOPLEX_DO_WITH_ERR_VERBOSITY( do_something ) { do_something; }
 #endif
 
-/// Prints out message \p x if the verbosity level is at least SPxOut::ERROR.
+/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_ERROR.
 #define SPX_MSG_ERROR(x)            { SOPLEX_DO_WITH_ERR_VERBOSITY( x ) }
-/// Prints out message \p x if the verbosity level is at least SPxOut::WARNING.
-#define SPX_MSG_WARNING(spxout, x)  { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::WARNING, spxout, x ) }
-/// Prints out message \p x if the verbosity level is at least SPxOut::INFO1.
-#define SPX_MSG_INFO1(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::INFO1, spxout, x ) }
-/// Prints out message \p x if the verbosity level is at least SPxOut::INFO2.
-#define SPX_MSG_INFO2(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::INFO2, spxout, x ) }
-/// Prints out message \p x if the verbosity level is at least SPxOut::INFO3.
-#define SPX_MSG_INFO3(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::INFO3, spxout, x ) }
+/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_WARNING.
+#define SPX_MSG_WARNING(spxout, x)  { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::VERB_WARNING, spxout, x ) }
+/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_INFO1.
+#define SPX_MSG_INFO1(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::VERB_INFO1, spxout, x ) }
+/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_INFO2.
+#define SPX_MSG_INFO2(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::VERB_INFO2, spxout, x ) }
+/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_INFO3.
+#define SPX_MSG_INFO3(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::VERB_INFO3, spxout, x ) }
 
 extern bool msginconsistent(const char* name, const char* file, int line);
 

--- a/src/soplex/spxdefines.h
+++ b/src/soplex/spxdefines.h
@@ -26,9 +26,9 @@
  * @brief Debugging, floating point type and parameter definitions.
  *
  * In optimized code with \c NDEBUG defined, only
- * \ref soplex::SPxOut::VERB_INFO1 "INFO1",
- * \ref soplex::SPxOut::VERB_INFO2 "INFO2", and
- * \ref soplex::SPxOut::VERB_INFO3 "INFO3" are set.
+ * \ref soplex::SPxOut::VERB_INFO1 "VERB_INFO1",
+ * \ref soplex::SPxOut::VERB_INFO2 "VERB_INFO2", and
+ * \ref soplex::SPxOut::VERB_INFO3 "VERB_INFO3" are set.
  * If \c NDEBUG is not defined, the code within \#TRACE is used.
  * If \c SOPLEX_DEBUG is defined, the code within
  * \ref soplex::SPxOut::VERB_DEBUG "DEBUG" is also used.

--- a/src/soplex/spxout.cpp
+++ b/src/soplex/spxout.cpp
@@ -30,14 +30,14 @@ namespace soplex
 {
 /// constructor
 SPxOut::SPxOut()
-   : m_verbosity(ERROR)
+   : m_verbosity(VERB_ERROR)
    , m_streams(nullptr)
 {
-   spx_alloc(m_streams, INFO3 + 1);
-   m_streams = new(m_streams) std::ostream*[INFO3 + 1];
-   m_streams[ ERROR ] = m_streams[ WARNING ] = &std::cerr;
+   spx_alloc(m_streams, VERB_INFO3 + 1);
+   m_streams = new(m_streams) std::ostream*[VERB_INFO3 + 1];
+   m_streams[ VERB_ERROR ] = m_streams[ VERB_WARNING ] = &std::cerr;
 
-   for(int i = DEBUG; i <= INFO3; ++i)
+   for(int i = VERB_DEBUG; i <= VERB_INFO3; ++i)
       m_streams[ i ] = &std::cout;
 }
 
@@ -54,7 +54,7 @@ SPxOut& SPxOut::operator=(const SPxOut& base)
    if(this != &base)
       m_verbosity = base.m_verbosity;
 
-   for(int i = DEBUG; i <= INFO3; ++i)
+   for(int i = VERB_DEBUG; i <= VERB_INFO3; ++i)
       m_streams[ i ] = base.m_streams[ i ];
 
    return *this;
@@ -64,11 +64,11 @@ SPxOut::SPxOut(const SPxOut& rhs)
 {
    m_verbosity = rhs.m_verbosity;
    m_streams = nullptr;
-   spx_alloc(m_streams, INFO3 + 1);
-   m_streams = new(m_streams) std::ostream*[INFO3 + 1];
-   m_streams[ ERROR ] = m_streams[ WARNING ] = rhs.m_streams[ERROR];
+   spx_alloc(m_streams, VERB_INFO3 + 1);
+   m_streams = new(m_streams) std::ostream*[VERB_INFO3 + 1];
+   m_streams[ VERB_ERROR ] = m_streams[ VERB_WARNING ] = rhs.m_streams[VERB_ERROR];
 
-   for(int i = DEBUG; i <= INFO3; ++i)
+   for(int i = VERB_DEBUG; i <= VERB_INFO3; ++i)
       m_streams[ i ] = rhs.m_streams[ i ];
 }
 

--- a/src/soplex/spxout.h
+++ b/src/soplex/spxout.h
@@ -61,16 +61,16 @@ struct EnableDebugOutput
    level. In particular, this means that the first element in an output stream
    should always be the verbosity. For instance, use
    @code
-      spxout << verb( SPxOut::WARNING ) << std::setw( 15 ) << 42 << std::endl;
+      spxout << verb( SPxOut::VERB_WARNING ) << std::setw( 15 ) << 42 << std::endl;
    @endcode
    or
    @code
-      spxout.setVerbosity( SPxOut::WARNING );
+      spxout.setVerbosity( SPxOut::VERB_WARNING );
       spxout << std::setw( 15 ) << 42 << std::endl;
    @endcode
    instead of
    @code
-      spxout << std::setw( 15 ) << verb( SPxOut::WARNING ) << 42 << std::endl;
+      spxout << std::setw( 15 ) << verb( SPxOut::VERB_WARNING ) << 42 << std::endl;
    @endcode
    in order to make sure that @c std::setw( 15 ) is applied to the warning stream.
 */
@@ -85,15 +85,15 @@ public:
    /// Verbosity level
    typedef enum
    {
-      // Note: the implementation uses the fact that ERROR == 0
-      // and that the verbosity levels are subsequent numbers.
-      // If you change this, change the implementation as well.
-      ERROR    = 0,
-      WARNING  = 1,
-      DEBUG    = 2,
-      INFO1    = 3,
-      INFO2    = 4,
-      INFO3    = 5
+      // Note: the implementation uses the fact that VERB_ERROR == 0 and that
+      // the verbosity levels are subsequent numbers. If you change this,
+      // change the implementation as well.
+      VERB_ERROR    = 0,
+      VERB_WARNING  = 1,
+      VERB_DEBUG    = 2,
+      VERB_INFO1    = 3,
+      VERB_INFO2    = 4,
+      VERB_INFO3    = 5
    } Verbosity;
 
    /// helper struct for the output operator
@@ -240,7 +240,7 @@ private:
     Calling
     @code
          SPxOut spxout;
-         spxout << verb( SPxOut::ERROR ) << "This is an error!" << std::endl;
+         spxout << verb( SPxOut::VERB_ERROR ) << "This is an error!" << std::endl;
     @endcode
     passes such a struct to the output operator defined below, which
     extracts the verbosity level from the struct and passes it to the

--- a/src/soplex/validation.hpp
+++ b/src/soplex/validation.hpp
@@ -91,7 +91,7 @@ void Validation<R>::validateSolveReal(SoPlexBase<R>& soplex)
    R sumDualViolation = 0.0;
    R sol;
 
-   std::ostream& os = soplex.spxout.getStream(SPxOut::INFO1);
+   std::ostream& os = soplex.spxout.getStream(SPxOut::VERB_INFO1);
 
    if(validatesolution == "+infinity")
    {

--- a/src/soplexmain.cpp
+++ b/src/soplexmain.cpp
@@ -1380,7 +1380,7 @@ int runSoPlex(int argc, char* argv[])
       if(displayStatistics)
       {
          SPX_MSG_INFO1(soplex->spxout, soplex->spxout << "Statistics\n==========\n\n");
-         soplex->printStatistics(soplex->spxout.getStream(SPxOut::INFO1));
+         soplex->printStatistics(soplex->spxout.getStream(SPxOut::VERB_INFO1));
       }
 
       if(validation->validate)

--- a/tests/exercise_LP_changes.cpp
+++ b/tests/exercise_LP_changes.cpp
@@ -82,7 +82,7 @@ public:
    static const Real epsilon;
    static const Real epsilon_factor;
    static const Real epsilon_update;
-   static const int verbose = SPxOut::ERROR;
+   static const int verbose = SPxOut::VERB_ERROR;
    static const int precision = 12;
    ///@}
 


### PR DESCRIPTION
Fixes https://github.com/scipopt/soplex/issues/47