### PR TITLE
Use external fmt as optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(SANITIZE "should sanitizers be enabled if available" OFF)
 option(COVERAGE "enable coverage support" OFF)
 option(PAPILO "should papilo library be linked" ON)
 option(LTO "Enable Link Time Optimization, aka Interprocedural Optimization" OFF)
+option(SYSTEM_FMT "Use system fmt library. Otherwise, use bundled fmt" OFF)
 
 if(LTO)
     include(CheckIPOSupported)
@@ -150,6 +151,12 @@ if(COVERAGE)
     SETUP_TARGET_FOR_COVERAGE(NAME coverage
                           EXECUTABLE bash -c "ctest ${COVERAGE_CTEST_ARGS}"
                           DEPENDENCIES soplex)
+endif()
+
+if (SYSTEM_FMT)
+    find_package(fmt REQUIRED)
+    set(libs ${libs} fmt::fmt)
+    add_compile_definitions(SOPLEX_WITH_SYSTEM_FMT)
 endif()
 
 if(ZLIB)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,20 +221,22 @@ set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/$
 install(FILES ${headers} ${PROJECT_BINARY_DIR}/soplex/config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/soplex)
 install(FILES soplex.h soplex.hpp soplex_interface.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(FILES
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/chrono.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/color.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/compile.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/core.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/format-inl.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/format.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/locale.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/os.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/ostream.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/posix.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/printf.h
-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/ranges.h
-     DESTINATION include/soplex/external/fmt)
+if(NOT SYSTEM_FMT)
+    install(FILES
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/chrono.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/color.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/compile.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/core.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/format-inl.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/format.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/locale.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/os.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/ostream.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/posix.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/printf.h
+        ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/ranges.h
+        DESTINATION include/soplex/external/fmt)
+endif()
 
 # TODO this is necessary only if ZLIB_FOUND?
 install(FILES
@@ -256,7 +258,9 @@ endif()
 
 # install license files of soplex and fmt
 install(FILES ${PROJECT_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex)
-install(FILES ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/LICENSE.rst DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex/fmt)
+if (NOT SYSTEM_FMT)
+    install(FILES ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/LICENSE.rst DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex/fmt)
+endif()
 
 # Add library targets to the build-tree export set
 export(TARGETS libsoplex libsoplex-pic libsoplexshared

--- a/src/soplex/fmt.hpp
+++ b/src/soplex/fmt.hpp
@@ -34,8 +34,11 @@
 #include "papilo/Config.hpp"
 #endif
 
+#if defined(SOPLEX_WITH_SYSTEM_FMT)
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 /* to provide backwards compatibility use fmt of PaPILO <= 2.3 due to breaking changes in fmt 7 */
-#if !defined(SOPLEX_WITH_PAPILO) || PAPILO_VERSION_MAJOR > 2 || (PAPILO_VERSION_MAJOR == 2 && PAPILO_VERSION_MINOR > 3)
+#elif !defined(SOPLEX_WITH_PAPILO) || PAPILO_VERSION_MAJOR > 2 || (PAPILO_VERSION_MAJOR == 2 && PAPILO_VERSION_MINOR > 3)
 #include "soplex/external/fmt/format.h"
 #include "soplex/external/fmt/ostream.h"
 #else


### PR DESCRIPTION
Greetings!

As discussed on #54, this PR brings the opportunity to consume fmt from the system instead of using the bundled fmt in SoPlex. 

It adds the CMake option `SYSTEM_FMT` which is disabled by default, as asked in the issue. Then, when active, it expects to find fmt and link to the CMake target `fmt:fmt`

I also added the definition `SOPLEX_WITH_SYSTEM_FMT`, so `soplex/fmt.hpp` will consume external fmt as well. 

I tested locally using Conan, but all CMake commands are explicit, so you can see each build step/command as well: [soplex-8.1.0-dev-osx-armv8-clang21-release-shared.log](https://github.com/user-attachments/files/30587926/soplex-8.1.0-dev-osx-armv8-clang21-release-shared.log)

close #54

Regards! 	